### PR TITLE
Feature: Display tags in home page listing

### DIFF
--- a/assets/css/common/post-entry.css
+++ b/assets/css/common/post-entry.css
@@ -25,7 +25,7 @@
     -webkit-line-clamp: 3;
 }
 
-.first-entry .entry-footer {
+.entry-tags-container, .first-entry .entry-footer {
     font-size: 14px;
 }
 
@@ -70,6 +70,32 @@
 .entry-footer {
     color: var(--secondary);
     font-size: 13px;
+}
+
+.entry-tags-container {
+  color: var(--secondary);
+  padding-top: 10px;
+  font-size: 15px;
+}
+
+.entry-tags {
+  padding: 0;
+  margin: 0;
+}
+
+.entry-tags li {
+  z-index: 10;
+  display: inline-block;
+  margin-inline-end: 3px;
+}
+
+.entry-tags a {
+  border-radius: var(--radius);
+}
+
+.entry-tags a:hover {
+  color: Salmon;
+  text-decoration: underline;
 }
 
 .entry-link {

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -53,7 +53,7 @@
   {{- partial "cover.html" (dict "cxt" . "IsHome" true "isHidden" $isHidden) }}
   <header class="entry-header">
     <h2>
-      {{- .Title }}
+      <a aria-label="post link to {{ .Title | plainify }}" href="{{ .Permalink }}">{{- .Title }}</a>
       {{- if .Draft }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[draft]</span></sup>{{- end }}
     </h2>
   </header>
@@ -63,11 +63,21 @@
   </section>
   {{- end }}
   {{- if not (.Param "hideMeta") }}
-  <footer class="entry-footer">
+  <section class="entry-footer">
     {{- partial "post_meta.html" . -}}
+  </section>
+  {{- if (ne (.Param "hideHomeTags") true) }}
+  <footer class="entry-tags-container">
+      {{- if .Params.tags }}
+      <ul class="entry-tags">
+        {{- range .Params.tags }}
+        <li><a href="{{ "tags/" | absLangURL }}{{ replace . " " "-" | urlize }}">#{{ replace . " " "-" }}</a></li>
+        {{- end }}
+      </ul>
+      {{- end }}
   </footer>
+  {{- end -}}
   {{- end }}
-  <a class="entry-link" aria-label="post link to {{ .Title | plainify }}" href="{{ .Permalink }}"></a>
 </article>
 {{- end }}
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -66,7 +66,7 @@
   <section class="entry-footer">
     {{- partial "post_meta.html" . -}}
   </section>
-  {{- if (ne (.Param "hideHomeTags") true) }}
+  {{- if (ne (.Param "HideHomeTags") true) }}
   <footer class="entry-tags-container">
       {{- if .Params.tags }}
       <ul class="entry-tags">


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

Display post tags on the home page listing all posts. This behavior can be disabled if needed by controlling the value of the `Params.HideHomeTags` boolean field.

**Was the change discussed in an issue or in the Discussions before?**

No

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.

### Changes to FrontMatter

This PR introduces a new field `Params.HideHomeTags` - if set to true, post tags won't be displayed on the home page, `false` by default i.e. **tags will be displayed on the home page by default**.

**Note:** Disabling this field can *potentially* reduce the build times for blogs with a large number of posts.

---

As an example, here are some temporary posts with the current `master`:

![image](https://user-images.githubusercontent.com/22884507/142671982-07421a93-e840-4a53-9665-ab220825a345.png)

And, this is the updated look with the changes made in this branch

![image](https://user-images.githubusercontent.com/22884507/142672150-3f27bc93-68ff-4c0a-b96d-7cc7442857e1.png)

Special thanks to [Anubis](https://github.com/Mitrichius/hugo-theme-anubis) which was used as a reference for this feature.