### PR TITLE
Update: Allow custom positioning for anchored tags

### DIFF
--- a/assets/css/common/post-single.css
+++ b/assets/css/common/post-single.css
@@ -356,16 +356,22 @@
     transform: scale(0.96);
 }
 
+.anchor {
+  box-shadow: none !important;
+  margin-inline-start: 8px;
+  display: inline-flex;
+  font-weight: 600;
+  opacity: 0;
+}
+
 h1:hover .anchor,
 h2:hover .anchor,
 h3:hover .anchor,
 h4:hover .anchor,
 h5:hover .anchor,
 h6:hover .anchor {
-    display: inline-flex;
+    opacity:    1;
     color: var(--secondary);
-    margin-inline-start: 8px;
-    font-weight: 500;
     user-select: none;
 }
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -30,7 +30,7 @@
   {{- if .Content }}
   <div class="post-content">
     {{- if not (.Param "disableAnchoredHeadings") }}
-    {{- partial "anchored_headings.html" .Content -}}
+    {{- partial "anchored_headings.html" . -}}
     {{- else }}{{ .Content }}{{ end }}
   </div>
   {{- end }}

--- a/layouts/partials/anchored_headings.html
+++ b/layouts/partials/anchored_headings.html
@@ -1,2 +1,7 @@
 {{- /* formats .Content headings by adding an anchor */ -}}
-{{ . | replaceRE "(<h[1-6] id=\"([^\"]+)\".+)(</h[1-6]+>)" "${1}<a hidden class=\"anchor\" aria-hidden=\"true\" href=\"#${2}\">#</a>${3}" | safeHTML }}
+
+{{ if .Site.Params.AnchorTagPositionLeft }}
+  {{- .Content | replaceRE "(<h[1-6] id=\"([^\"]+)\".*>)(.*)(</h[1-6]+>)" "${1}<a class=\"anchor\" href=\"#${2}\">#</a> ${3}${4}" | safeHTML -}}
+{{ else }}
+  {{- .Content | replaceRE "(<h[1-6] id=\"([^\"]+)\".+)(</h[1-6]+>)" "${1}<a hidden class=\"anchor\" aria-hidden=\"true\" href=\"#${2}\">#</a>${3}" | safeHTML -}}
+{{ end }}


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

For anchored headings, the default position for the anchor tag is to the right of the title. With this commit, users can control if they want the tag to appear on the left of the text or right.

This commit adds a parameter - `Params.AnchorTagPositionLeft` -- a boolean indicating if anchor tag is to be positioned on the left or not.

Note: The anchor tag will be placed on the right (by default) unless the user modifies this behavior.

**Was the change discussed in an issue or in the Discussions before?**

No

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.

### Changes to Front Matter

This PR introduces a new field - `Params.AnchorTagPositionLeft` - setting this field to `true` would place the anchor tag on the left of all headings. On the other hand, setting this field to false (or not using this field at all) - will default the anchor tag to be placed on the right of headings - same as before.

---

So far, the anchored tag was always placed on the right of headings - which made it look out of place (at least to me). 

The main reference for making this change was the final display of markdown pages on Github (and other sites) - most of which have the anchored tag placed on the left of headings. Which has conditioned me - and many others I believe - to reflexively reach out for the anchored tag on the left side of headings.