### PR TITLE
Feature: Display bottom borders for headings

### DIFF
--- a/assets/css/common/post-single.css
+++ b/assets/css/common/post-single.css
@@ -36,11 +36,18 @@
     color: var(--content);
 }
 
+.post-content h1,
+.post-content h2,
 .post-content h3,
 .post-content h4,
 .post-content h5,
 .post-content h6 {
     margin: 24px 0 16px;
+}
+
+.post-content h1,
+.post-content h2  {
+  border-bottom: 1.5px solid gray;
 }
 
 .post-content h1 {


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

The markdown output in sites such as Github includes a bottom border for titles (especially the `H1` and `H2` HTML tags). This PR implements the same functionality for this theme.

**Was the change discussed in an issue or in the Discussions before?**

No

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
