### PR TITLE
Feature: Add a `future` tag for future posts

### DIFF
--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -31,6 +31,7 @@
         <h3 class="archive-entry-title">
           {{- .Title | markdownify }}
           {{- if .Draft }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[draft]</span></sup>{{- end }}
+          {{- if gt (math.Max .Date.Unix .PublishDate.Unix) now.Unix }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[future]</span></sup>{{- end }}
         </h3>
         <div class="archive-meta">
           {{- partial "post_meta.html" . -}}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -55,6 +55,7 @@
     <h2>
       {{- .Title }}
       {{- if .Draft }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[draft]</span></sup>{{- end }}
+      {{- if gt (math.Max .Date.Unix .PublishDate.Unix) now.Unix }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[future]</span></sup>{{- end }}
     </h2>
   </header>
   {{- if (ne (.Param "hideSummary") true) }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -6,6 +6,7 @@
     <h1 class="post-title">
       {{ .Title }}
       {{- if .Draft }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[draft]</span></sup>{{- end }}
+      {{- if gt (math.Max .Date.Unix .PublishDate.Unix) now.Unix }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[future]</span></sup>{{- end }}
     </h1>
     {{- if .Description }}
     <div class="post-description">


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

Posts that are to be released in the future will now contain a `future` tag -- this is similar to the already existing `draft` tag for posts marked as drafts.

To consider a post as a future post, the template will check if either the "*date*" or the "*publishDate*" field in the front-matter is greater than the current time. If yes, the post will be considered as a future post, and the `future` tag will be displayed on the post.

Note: By default, "*Page.PublishDate*" contains the same value as "*Page.Date*" unless explicitly modified.

**Was the change discussed in an issue or in the Discussions before?**

No

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
