### PR TITLE
Feature: Add an `expired` tag for expired posts

### DIFF
--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -32,6 +32,7 @@
           {{- .Title | markdownify }}
           {{- if .Draft }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[draft]</span></sup>{{- end }}
           {{- if gt (math.Max .Date.Unix .PublishDate.Unix) now.Unix }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[future]</span></sup>{{- end }}
+          {{- if (and .ExpiryDate (lt .ExpiryDate.Unix now.Unix)) }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[expired]</span></sup>{{- end }}
         </h3>
         <div class="archive-meta">
           {{- partial "post_meta.html" . -}}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -56,6 +56,7 @@
       <a aria-label="post link to {{ .Title | plainify }}" href="{{ .Permalink }}">{{- .Title }}</a>
       {{- if .Draft }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[draft]</span></sup>{{- end }}
       {{- if gt (math.Max .Date.Unix .PublishDate.Unix) now.Unix }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[future]</span></sup>{{- end }}
+      {{- if (and .ExpiryDate (lt .ExpiryDate.Unix now.Unix)) }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[expired]</span></sup>{{- end }}
     </h2>
   </header>
   {{- if (ne (.Param "hideSummary") true) }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -7,6 +7,7 @@
       {{ .Title }}
       {{- if .Draft }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[draft]</span></sup>{{- end }}
       {{- if gt (math.Max .Date.Unix .PublishDate.Unix) now.Unix }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[future]</span></sup>{{- end }}
+      {{- if (and .ExpiryDate (lt .ExpiryDate.Unix now.Unix)) }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[expired]</span></sup>{{- end }}
     </h1>
     {{- if .Description }}
     <div class="post-description">


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

This branch introduces an `expired` tag for expired posts. The tag is similar to the existing `future` and `draft` tag to point out unpublished or draft posts respectively. Building on the same functionality, the presence of an `expired` tag would make it easy to identify *expired* posts that will no longer be visible.

#### Identifying `expired` posts

To identify an expired post, the template will check for presence of the `expiryDate` tag in post metadata. Posts having an "*expiryDate*" tag with, with a *date-time* value less than the current time (at the time of execution), will be considered to be expired posts, and will have an `expired` displayed alongside them

**Was the change discussed in an issue or in the Discussions before?**

No

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
