### PR TITLE
Fix: Remove bottom shadow and underlines from footnotes

### DIFF
--- a/assets/css/common/post-single.css
+++ b/assets/css/common/post-single.css
@@ -36,6 +36,11 @@
     color: var(--content);
 }
 
+sup .footnote-ref {
+  text-decoration: none !important;
+  box-shadow: none !important;
+}
+
 .post-content h1,
 .post-content h2,
 .post-content h3,


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

Add CSS rules to prevent displaying bottom borders or shadows to footnotes. Footnotes with bottom borders looked out of the place. The new rules added are marked as important to ensure they override any conflicting CSS styles from before

The rules added selectively target the `footnote-ref` class within the `sup` HTML tag to ensure this change affects only footnotes that are super-scripted.

**Was the change discussed in an issue or in the Discussions before?**

Yes, closes #7 

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
