### PR TITLE
Feature: Add hover transition for bottom borders in headings

### DIFF
--- a/assets/css/common/post-single.css
+++ b/assets/css/common/post-single.css
@@ -60,8 +60,14 @@ sup .footnote-ref:hover {
 .post-content h2  {
   padding-left: 2px;
   padding-right: 2px;
-  padding-bottom: 3px;
+  padding-bottom: 9px;
+  transition: 0.2s all ease;
   border-bottom: 1.5px solid gray;
+}
+
+.post-content h1:hover,
+.post-content h2:hover  {
+    padding-bottom: 5px;
 }
 
 .post-content h1 {


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

Adds a nice transition effect for `H1` and `H2` HTML tags. Increase bottom padding for both of them to be at 9px.

During a `hover` event, this bottom padding will be reduced to 5px in a duration of 0.2 seconds.

**Was the change discussed in an issue or in the Discussions before?**

No

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
