### PR TITLE
Feature: Center tables

### DIFF
--- a/assets/css/common/post-single.css
+++ b/assets/css/common/post-single.css
@@ -157,6 +157,7 @@ sup .footnote-ref:hover {
 
 .post-content table {
     margin-bottom: 32px;
+    margin: 0 auto;
 }
 
 .post-content table th,

--- a/assets/css/core/reset.css
+++ b/assets/css/core/reset.css
@@ -38,8 +38,7 @@ header,
 hgroup,
 main,
 nav,
-section,
-table {
+section {
     display: block;
 }
 


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

Ensures tables fill the complete width available, centering their contents at the same time.

**Was the change discussed in an issue or in the Discussions before?**

No

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.