### PR TITLE
Fix: Ensure complete `article` element on list page is linked

### DIFF
--- a/assets/css/common/post-entry.css
+++ b/assets/css/common/post-entry.css
@@ -73,6 +73,8 @@
 }
 
 .entry-tags-container {
+  z-index: 1;
+  position: sticky;
   color: var(--secondary);
   padding-top: 10px;
   font-size: 15px;

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -49,11 +49,13 @@
 {{- end }}
 
 <article class="{{ $class }}">
+  <a class="entry-link" aria-label="post link to {{ .Title | plainify }}" href="{{ .Permalink }}"></a>
+  
   {{- $isHidden := (.Site.Params.cover.hidden | default .Site.Params.cover.hiddenInList) }}
   {{- partial "cover.html" (dict "cxt" . "IsHome" true "isHidden" $isHidden) }}
   <header class="entry-header">
     <h2>
-      <a aria-label="post link to {{ .Title | plainify }}" href="{{ .Permalink }}">{{- .Title }}</a>
+      {{- .Title }}
       {{- if .Draft }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[draft]</span></sup>{{- end }}
       {{- if gt (math.Max .Date.Unix .PublishDate.Unix) now.Unix }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[future]</span></sup>{{- end }}
       {{- if (and .ExpiryDate (lt .ExpiryDate.Unix now.Unix)) }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[expired]</span></sup>{{- end }}


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

This commit intends to patch the *loss of functionality* caused as a side-effect of PR #1. 

![image](https://user-images.githubusercontent.com/22884507/144862310-eba1c029-2f36-46ae-bced-5409c286e70f.png)

Apparently, links in HTML can't be nested. In order to add ensure article tags in the home page link to the *tags* page, the link from the main `article` element in the home page was moved to the post title.

Meaning users would need to click the title of the post to read the post, instead of being able to click anywhere on the article block (which was the case before this change)!

This commit intends to restore the previous functionality - i.e. ensure the entire article block is clickable, along with tags containing their own links.

**Was the change discussed in an issue or in the Discussions before?**

No

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
