### PR TITLE
Feature: Define custom popups for `abbr` tag

### DIFF
--- a/assets/css/common/post-single.css
+++ b/assets/css/common/post-single.css
@@ -248,6 +248,11 @@ abbr[full-form]:focus::after {
     padding: 5px 7px;
 }
 
+.dark abbr[full-form]:hover::after,
+.dark abbr[full-form]:focus::after {
+    background: var(--entry);
+}
+
 .post-content code {
     margin: auto 4px;
     padding: 4px 6px;

--- a/assets/css/common/post-single.css
+++ b/assets/css/common/post-single.css
@@ -221,6 +221,33 @@ sup .footnote-ref:hover {
     display: none;
 }
 
+abbr[full-form] {
+    position: relative;
+
+    /* ensure consistent styling across browsers */
+    text-decoration: underline dotted; 
+}
+
+abbr[full-form]:hover::after,
+abbr[full-form]:focus::after {
+    content: attr(full-form);
+
+    /* position tooltip like the native one */
+    position: absolute;
+    left: 0;
+    bottom: -30px;
+    width: auto;
+    white-space: nowrap;
+
+    /* style tooltip */
+    background-color: #1e1e1e;
+    color: #fff;
+    border-radius: 3px;
+    box-shadow: 1px 1px 5px 0 rgba(0,0,0,0.4);
+    font-size: 14px;
+    padding: 5px 7px;
+}
+
 .post-content code {
     margin: auto 4px;
     padding: 4px 6px;


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

Add a custom popup that can be used as a replacement for the default `abbr` tag. 

One of the major problems being caused by the default HTML `abbr` tag was limited/no support for mobile and touch devices in general!

With the changes introduced in this branch, `abbr` tags can now work with mobile devices as well. Along with that, the UI for tooltip generated has been modified to align it with the rest of the theme

Using this modified version is as simple as

```html
<abbr full-form="World Wide Web">www</abbr>
```

Note the usage of `full-form` data field, as opposed to `title` used by traditional `abbr` elements

This means, if needed, replacing this custom `abbr` tag with the default tag is as simple as

```html
<abbr title="World Wide Web">www</abbr>
```

Simply changing the field from `full-form` to `title` would be enough! As such, it is possible to switch abbreviation tags (between this version, and traditional the `abbr` tag) being used throughout a repository with simple tools like [grep](https://www.gnu.org/software/grep/manual/grep.html) or [git-grep](https://git-scm.com/docs/git-grep)

**Was the change discussed in an issue or in the Discussions before?**

No

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
