### PR TITLE
Feature: Add global param to disable descriptions in posts

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -9,7 +9,7 @@
       {{- if gt (math.Max .Date.Unix .PublishDate.Unix) now.Unix }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[future]</span></sup>{{- end }}
       {{- if (and .ExpiryDate (lt .ExpiryDate.Unix now.Unix)) }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[expired]</span></sup>{{- end }}
     </h1>
-    {{- if .Description }}
+    {{- if (and .Description .Site.Params.showDescriptionInPost) }}
     <div class="post-description">
       {{ .Description | markdownify }}
     </div>


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

Add a new site param - `params.showDescriptionInPost` to allow users to decide if they want to display post description in
posts page or not!

If disabled, the post description will still be a part of the RSS feed, but won't be a part of the page itself.

**Was the change discussed in an issue or in the Discussions before?**
No

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
