### PR TITLE
Update: Display an additional listing page as home page

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -4,7 +4,9 @@
 {{- partial "index_profile.html" . }}
 {{- else }} {{/* if not profileMode */}}
 
-{{- if not .IsHome | and .Title }}
+{{ $isCustomHome := (eq (lower (trim .RelPermalink "/\\")) (lower site.Params.profileMode.altHomePage)) }}
+
+{{- if not (or .IsHome $isCustomHome) | and .Title }}
 <header class="page-header">
   {{- partial "breadcrumbs.html" . }}
   <h1>{{ .Title }}</h1>
@@ -32,7 +34,7 @@
 
 {{- $paginator := .Paginate $pages }}
 
-{{- if and .IsHome site.Params.homeInfoParams (eq $paginator.PageNumber 1) }}
+{{- if and (or .IsHome $isCustomHome) site.Params.homeInfoParams (eq $paginator.PageNumber 1) }}
 {{- partial "home_info.html" . }}
 {{- end }}
 


### PR DESCRIPTION
<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

In simple terms — the central goal for this PR is to allow sites generated using `paper-mod` to have profile mode, and a home page. As of now, I am forced to choose between the two - the site can either have profile mode, or a central homepage.

This change introduces a new front-matter variable:
```text
params.profileMode.altHomePage
```

The value against the variable should be the name of the directory (within the `contents` directory) that should be used as the central home page. Post this, simply enable `params.profileMode`

With this, the root home page for the site (at `localhost` in case of local builds) will be the profile mode, and the website would have a custom home page at: `localhost/<altHomePage>`

**Was the change discussed in an issue or in the Discussions before?**

Yes, resolves #18 

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
